### PR TITLE
remove es6 arrow functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ class PersonalityConsumptionPreferences {
   }
 
   descriptions() {
-    return pairs(this._data).map(p => p[1]);
+    return pairs(this._data).map(function(p) { return p[1]; });
   }
 }
 


### PR DESCRIPTION
Usage of arrow functions causes runtime issues with ionic + angular